### PR TITLE
switch --frontend-opt(deprecated) to --opt (in README.md)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ docker build -f manifest.yml .
 
 #### With `buildctl`:
 ```
-buildctl build --frontend=gateway.v0 --frontend-opt source=tonistiigi/pack --local context=.
+buildctl build --frontend=gateway.v0 --opt source=tonistiigi/pack --local context=.
 ```
 
 ### Options


### PR DESCRIPTION
got warning by the following command

```
buildctl build --frontend=gateway.v0 --frontend-opt source=tonistiigi/pack --local context=.
```

warn
```
WARN[0000] --frontend-opt <opt>=<optval> is deprecated. Please use --opt <opt>=<optval> instead.
```
